### PR TITLE
fix: Correct variable name prepedCustomerProperties -> customerProperties

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -206,11 +206,10 @@ class Klaviyo {
     this.ensureIdentifier(customerProperties);
 
     this.logger.log('verbose', `Sending Klaviyo an identify event \
-      for user ${prepedCustomerProperites.$id ||
-      prepedCustomerProperites.$email}`);
+      for user ${customerProperties.$id || customerProperties.$email}`);
 
     const data = {
-      'properties': prepedCustomerProperites,
+      'properties': customerProperties,
     };
 
 


### PR DESCRIPTION
Looks like this variable was missed in commit 6ebb19e4.